### PR TITLE
Add SAELogits to steering leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,6 +408,15 @@
           </tr>
           <tr>
             <td>6</td>
+            <td>SAELogits <a href="https://lukagerlach.github.io/SAELogits/" target="_blank" rel="noopener">[Gerlach, 2026]</a></td>
+            <td class="dash">—</td>
+            <td class="dash">—</td>
+            <td class="dash">—</td>
+            <td>0.351</td>
+            <td>0.351</td>
+          </tr>
+          <tr>
+            <td>7</td>
             <td>DiffMean</td>
             <td>0.297</td>
             <td>0.178</td>
@@ -416,7 +425,7 @@
             <td>0.239</td>
           </tr>
           <tr>
-            <td>7</td>
+            <td>8</td>
             <td>SAE</td>
             <td>0.177</td>
             <td>0.151</td>
@@ -425,7 +434,7 @@
             <td>0.165</td>
           </tr>
           <tr>
-            <td>8</td>
+            <td>9</td>
             <td>SAE-A</td>
             <td>0.166</td>
             <td>0.132</td>
@@ -434,7 +443,7 @@
             <td>0.157</td>
           </tr>
           <tr>
-            <td>9</td>
+            <td>10</td>
             <td>LAT</td>
             <td>0.117</td>
             <td>0.130</td>
@@ -443,7 +452,7 @@
             <td>0.127</td>
           </tr>
           <tr>
-            <td>10</td>
+            <td>11</td>
             <td>PCA</td>
             <td>0.107</td>
             <td>0.083</td>
@@ -452,7 +461,7 @@
             <td>0.105</td>
           </tr>
           <tr>
-            <td>11</td>
+            <td>12</td>
             <td>Probe</td>
             <td>0.095</td>
             <td>0.091</td>


### PR DESCRIPTION
## Summary
- Add SAELogits method to the rank-1 steering leaderboard on the homepage
- Results for 9B L31 (0.351), other configs pending
- Links to https://lukagerlach.github.io/SAELogits/

## Test plan
- [ ] Verify leaderboard renders correctly on the homepage
- [ ] Confirm rank ordering is correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)