### PR TITLE
Add FLAS to leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@
 | PCA                          | 0.107 | 0.083 | 0.128 | 0.104 | 0.105 |
 | Probe                        | 0.095 | 0.091 | 0.108 | 0.099 | 0.098 |
 
+### Beyond rank-1
+
+Steering methods whose intervention is not restricted to a single direction.
+
+| Method                       | 2B L10 | 2B L20 | 9B L20 | 9B L31 |  Avg |
+|------------------------------|-------:|-------:|-------:|-------:|-----:|
+| FLAS [[Jin et al., 2026]](https://flas-ai.github.io) | - | 1.025 | 1.185 | - | 1.105 |
+
+
 ## Highlights
 
 1. **Scalabale evaluation harness**: Framework for generating synthetic training + eval data from concept lists (e.g. GemmaScope SAE labels).


### PR DESCRIPTION
## Summary

- Add a "Beyond rank-1" subsection under the rank-1 steering leaderboard in the README, with FLAS (Flow-based Activation Steering) as a first entry
- Why a separate section: FLAS is not a rank-1 intervention. Rather than computing one steering vector per prompt and adding it at every position (as HyperSteer does), it integrates a learned velocity field over multiple steps, where the displacement is re-evaluated from the current activation at each step and differs across token positions. Recent methods like AcT and K-Steering also relax these restrictions, so this class may keep growing.
- Scores follow the main table's setting (held-in harmonic mean, layer 20, Concept16k): **1.025** on Gemma-2-2B-IT, **1.185** on Gemma-2-9B-IT, at a single fixed flow time with no per-concept tuning
- Left `index.html` untouched for now — happy to mirror the section there too if you'd like

- Website: https://flas-ai.github.io 
- Paper: https://arxiv.org/abs/2605.05892 
- Code: https://github.com/flas-ai/FLAS 
- Models: https://huggingface.co/flas-ai

## Possible follow-ups (if there's interest)

- Train a rank-1-constrained **FLAS-r1** for the main table, to see how much of the gain survives the restriction